### PR TITLE
Add use of coinselect to improve transaction sending

### DIFF
--- a/angular/src/app/account/account.component.html
+++ b/angular/src/app/account/account.component.html
@@ -228,7 +228,7 @@
         <mat-card-content>
           <p>{{ "Account.Network" | translate }}: {{ networkStatus.node.blockchain.chain }}</p>
           <p>{{ "Account.Height" | translate }}: {{ networkStatus.blockHeight }}</p>
-          <p>{{ "Account.RelayFee" | translate }}: {{ networkStatus.node.network.relayFee }}</p>
+          <p>{{ "Account.RelayFee" | translate }}: {{ networkStatus.node.network.relayFee * 100000 }} {{ "Account.SatByte" | translate }}</p>
           <p>{{ "Account.MemoryPool" | translate }}: {{ networkStatus.node.transactionsInPool }} {{ "Account.Transaction" | translate }}</p>
           <p>{{ "Account.Connections" | translate }}: {{ networkStatus.node.network.connections }}</p>
           <p>

--- a/angular/src/app/account/send-sidechain/address/send-address.component.html
+++ b/angular/src/app/account/send-sidechain/address/send-address.component.html
@@ -1,19 +1,22 @@
 <div class="send-header">
-  <div class="send-header-title"><h2>{{ "Account.Swap" | translate }} {{ sendService.network.symbol }}</h2></div>
-  <div class="send-header-actions"><button class="half-width" [routerLink]="['/', 'account', 'send']" mat-raised-button>{{ "Account.Back" | translate }}...</button></div>
+  <div class="send-header-title">
+    <h2>{{ "Account.Swap" | translate }} {{ sendService.network.symbol }}</h2>
+  </div>
+  <div class="send-header-actions">
+    <button class="half-width" [routerLink]="['/', 'account', 'send']" mat-raised-button>{{ "Account.Back" | translate }}...</button>
+  </div>
 </div>
 
 <form [formGroup]="form">
-
   <mat-form-field class="input-full-width" appearance="outline">
     <mat-label>{{ "Account.SelectSidechain" | translate }}</mat-label>
     <mat-select (selectionChange)="onSidechainSelectChanged($event)" [(value)]="sendSidechainService.selectedSidechain">
-      <mat-option *ngFor="let sidechain of sendService.network.sidechains" [value]="sidechain.symbol">{{sidechain.name}}</mat-option>
+      <mat-option *ngFor="let sidechain of sendService.network.sidechains" [value]="sidechain.symbol">{{ sidechain.name }}</mat-option>
     </mat-select>
   </mat-form-field>
 
   <div *ngIf="sendSidechainService.selectedSidechain != null">
-    <h3>{{ "Account.FederationSwapAddress" | translate }}: {{sendService.address}}</h3>
+    <h3>{{ "Account.FederationSwapAddress" | translate }}: {{ sendService.address }}</h3>
   </div>
 
   <div class="input-actions">
@@ -26,9 +29,9 @@
   </div>
 
   <mat-form-field class="input-full-width" appearance="outline">
-    <mat-label>{{sendSidechainService.selectedSidechain}} {{ "Account.SidechainAddress" | translate }}</mat-label>
-   <input matInput formControlName="sidechainAddressInput" [(ngModel)]="sendSidechainService.sidechainAddress" required />
-     <mat-error *ngIf="form.controls['sidechainAddressInput'].errors?.['invalid']">{{ "Account.AddressInvalid" | translate }}</mat-error>
+    <mat-label>{{ sendSidechainService.selectedSidechain }} {{ "Account.SidechainAddress" | translate }}</mat-label>
+    <input matInput formControlName="sidechainAddressInput" [(ngModel)]="sendSidechainService.sidechainAddress" required />
+    <mat-error *ngIf="form.controls['sidechainAddressInput'].errors?.['invalid']">{{ "Account.AddressInvalid" | translate }}</mat-error>
     <mat-error *ngIf="form.controls['sidechainAddressInput'].errors?.['required']">{{ "Account.AddressRequired" | translate }}</mat-error>
   </mat-form-field>
 
@@ -48,17 +51,18 @@
 
   <div class="confirmation-label" *ngIf="confirmationMessage">{{ confirmationMessage }}</div>
 
-  <mat-form-field class="input-full-width" appearance="outline">
-    <mat-label>{{ "Account.Fee" | translate }}</mat-label>
-    <input matInput formControlName="feeInput" [(ngModel)]="sendService.fee" required />
-    <mat-error *ngIf="form.controls['feeInput'].invalid">{{ "Account.FeeInvalid" | translate }}</mat-error>
-    <mat-hint *ngIf="sendService.feeError" align="start"
-      ><strong>{{ sendService.feeError }}</strong>
-    </mat-hint>
-    <mat-hint align="end">{{ "Account.MinimumFeeRate" | translate }}: {{ sendService.feeRate }} {{ "Account.SatByte" | translate }}</mat-hint>
-  </mat-form-field>
-
   <div *ngIf="optionsOpen">
+    <mat-form-field class="input-full-width" appearance="outline">
+      <mat-label>{{ "Account.Fee" | translate }} ({{ "Account.SatByte" | translate }})</mat-label>
+      <input matInput formControlName="feeInput" [(ngModel)]="sendService.fee" required />
+
+      <mat-error *ngIf="form.controls['feeInput'].errors?.['min']">{{ "Account.FeeAmountMin" | translate }}</mat-error>
+      <mat-error *ngIf="form.controls['feeInput'].errors?.['required']">{{ "Account.FeeAmountRequired" | translate }}</mat-error>
+      <mat-error *ngIf="form.controls['feeInput'].invalid">{{ "Account.FeeInvalid" | translate }}</mat-error>
+      <!-- <mat-hint *ngIf="sendService.feeError" align="start"><strong>{{ sendService.feeError }}</strong></mat-hint> -->
+      <!-- <mat-hint align="end">{{ "Account.MinimumFeeRate" | translate }}: {{ sendService.targetFeeRate }} || {{ "Account.SatByte" | translate }}</mat-hint> -->
+    </mat-form-field>
+
     <mat-form-field class="input-full-width" appearance="outline">
       <mat-label>{{ "Account.CustomChangeAddress" | translate }}</mat-label>
       <input matInput formControlName="changeAddressInput" [(ngModel)]="sendService.changeAddress" />
@@ -66,8 +70,8 @@
   </div>
 
   <button class="full-width" (click)="toggleOptions()" mat-raised-button>{{ "Account.Options" | translate }}...</button>
-  <br /><br />
-  <h3>{{ "Account.Total" | translate }}: {{ sendService.total | amount }} {{ sendService.network.symbol }}</h3>
+  <br /><br /><br />
+  <!-- <h3>{{ "Account.Total" | translate }}: {{ sendService.total | amount }} {{ sendService.network.symbol }}</h3> -->
 </form>
 
 <button class="full-width" [disabled]="!form.valid" mat-raised-button routerLink="../confirm" color="primary">{{ "Account.Continue" | translate }}</button>

--- a/angular/src/app/account/send-sidechain/confirm/send-confirm.component.html
+++ b/angular/src/app/account/send-sidechain/confirm/send-confirm.component.html
@@ -1,43 +1,89 @@
-<h2>Confirm {{sendSidechainService.selectedSidechain}} Swap</h2>
+<h2>Confirm {{ sendSidechainService.selectedSidechain }} Swap</h2>
 
 <div class="grid-row-label-value">
-    <div><span>{{ "Account.FederationAddress" | translate }}</span><span>{{sendService.address}}</span></div>
-    <div><span>{{ "Account.TargetAddressOn" | translate }} {{sendSidechainService.selectedSidechain}}</span><span>{{sendSidechainService.sidechainAddress}}</span></div>
-    <div><span>{{ "Account.From" | translate }}</span><span>{{sendService.account.name}}</span></div>
-    <div *ngIf="sendService.changeAddress"><span>{{ "Account.Change" | translate }}</span><span>{{sendService.changeAddress}}</span></div>
-    <div><span>{{ "Account.Amount" | translate }}</span><span>{{sendService.amountAsSatoshi | amount}} {{sendService.network.symbol}}</span></div>
+  <div>
+    <span>{{ "Account.FederationAddress" | translate }}</span
+    ><span>{{ sendService.address }}</span>
+  </div>
+  <div>
+    <span>{{ "Account.TargetAddressOn" | translate }} {{ sendSidechainService.selectedSidechain }}</span
+    ><span>{{ sendSidechainService.sidechainAddress }}</span>
+  </div>
+  <div>
+    <span>{{ "Account.From" | translate }}</span
+    ><span>{{ sendService.account.name }}</span>
+  </div>
+  <div *ngIf="sendService.changeAddress">
+    <span>{{ "Account.Change" | translate }}</span
+    ><span>{{ sendService.changeAddress }}</span>
+  </div>
+  <div>
+    <span>{{ "Account.Amount" | translate }}</span
+    ><span>{{ sendService.amountAsSatoshi | amount }} {{ sendService.network.symbol }}</span>
+  </div>
 
-    <!-- <div><span>Fee</span><span>{{sendService.fee}} ({{sendService.feeAsSatoshi}}) {{sendService.network.symbol}}</span></div> -->
-    <div *ngIf="transaction"><span>{{ "Account.Fee" | translate }}</span><span>{{transaction.fee | amount}} {{sendService.network.symbol}}</span></div>
+  <!-- <div><span>Fee</span><span>{{sendService.fee}} ({{sendService.feeAsSatoshi}}) {{sendService.network.symbol}}</span></div> -->
+  <div *ngIf="transaction">
+    <span>{{ "Account.Fee" | translate }}</span
+    ><span>{{ transaction.fee | amount }} {{ sendService.network.symbol }}</span>
+  </div>
+  <div *ngIf="transaction">
+    <span>~{{ "Account.FeeRate" | translate }}</span
+    ><span>{{ transaction.feeRate }} {{ "Account.SatByte" | translate }}</span>
+  </div>
 
-    <div *ngIf="transaction"><span>{{ "Account.FeeRate" | translate }}</span><span>{{transaction.feeRate}} {{ "Account.SatByte" | translate }}</span></div>
-    <div *ngIf="invalidFeeAmount" class="mat-error"><span>{{ "Account.FeeRateTooLow" | translate }}</span><span>{{sendService.feeRate}} {{ "Account.SatByte" | translate }}</span></div>
-
-    <!-- <div *ngIf="transaction"><span>virtualSize</span><span>{{transaction.virtualSize}}</span></div>
+  <!-- <div *ngIf="transaction"><span>virtualSize</span><span>{{transaction.virtualSize}}</span></div>
     <div *ngIf="transaction"><span>weight</span><span>{{transaction.weight}}</span></div> -->
 
-    <div *ngIf="detailsOpen" class="grid-row-label-value">
+  <div *ngIf="detailsOpen" class="grid-row-label-value">
+    <div *ngIf="transaction">
+      <span>{{ "Account.ChangeAmount" | translate }}</span
+      ><span>{{ transaction.changeAmount | amount }} {{ sendService.network.symbol }}</span>
+    </div>
+    <div *ngIf="transaction">
+      <span>{{ "Account.ChangeAddress" | translate }}</span
+      ><span>{{ transaction.changeAddress }}</span>
+    </div>
 
-        <div *ngIf="transaction"><span>{{ "Account.ChangeAmount" | translate }}</span><span>{{transaction.changeAmount | amount}} {{sendService.network.symbol}}</span></div>
-        <div *ngIf="transaction"><span>{{ "Account.ChangeAddress" | translate }}</span><span>{{transaction.changeAddress}}</span></div>
+    <div *ngIf="transaction">
+      <span>{{ "Account.VirtualSize" | translate }}</span
+      ><span>{{ transaction.virtualSize }} bytes</span>
+    </div>
+    <div *ngIf="transaction">
+      <span>{{ "Account.Weight" | translate }}</span
+      ><span>{{ transaction.weight }} bytes</span>
+    </div>
 
-        <div *ngIf="transaction"><span>{{ "Account.Weight" | translate }}</span><span>{{transaction.weight | size }} </span></div>
-        <div *ngIf="transaction"><span>{{ "Account.VirtualSize" | translate }</span><span>{{transaction.virtualSize | size }} </span></div>
+    <div *ngIf="transaction">
+      <span>Inputs</span><span> {{ transaction.transaction.txInputs.length }} UTXOs</span>
+    </div>
 
-        <!-- <mat-form-field class="input-full-width" appearance="outline">
+    <div *ngIf="transaction">
+      <span>Outputs</span
+      ><span>
+        {{ transaction.transaction.txOutputs.length }} UTXOs<br /><br />
+
+        <div *ngFor="let output of transaction.transaction.txOutputs">{{ output.value | amount }} {{ sendService.network.symbol }} to address: {{ output.address }}</div></span
+      >
+    </div>
+
+    <!-- <mat-form-field class="input-full-width" appearance="outline">
             <mat-label>Custom change address</mat-label>
             <input matInput formControlName="changeAddressInput" [(ngModel)]="sendService.changeAddress">
         </mat-form-field> -->
+  </div>
 
-    </div>
+  <button class="full-width" (click)="toggleDetails()" mat-raised-button>{{ "Account.Details" | translate }}</button>
 
-    <button class="full-width" (click)="toggleDetails()" mat-raised-button>Details...</button>
+  <div>
+    <span>{{ "Account.Total" | translate }}</span
+    ><span class="total" *ngIf="sendService.total">{{ sendService.total | amount }} {{ sendService.network.symbol }}</span>
+  </div>
 
-    <div><span>Total</span><span class="total">{{sendService.total | amount}} {{sendService.network.symbol}}</span></div>
-
-    <div *ngIf="error" class="icon-warn">
-        <h2>ERROR</h2><span>{{error}}</span>
-    </div>
+  <div *ngIf="error" class="icon-warn">
+    <h2>{{ "Account.Error" | translate }}</h2>
+    <span>{{ error }}</span>
+  </div>
 </div>
 
 <!-- <p>Sending to:</p>
@@ -75,7 +121,7 @@
     <mat-label>Fee</mat-label>
     <input matInput [(ngModel)]="sendService.fee" required>
 </mat-form-field> -->
-<br>
+<br />
 
 <button class="full-width" [disabled]="!valid" mat-raised-button routerLink="../sending" color="primary">{{ "Account.Send" | translate }}</button>
 

--- a/angular/src/app/account/send-sidechain/sending/send-sending.component.ts
+++ b/angular/src/app/account/send-sidechain/sending/send-sending.component.ts
@@ -32,7 +32,6 @@ export class AccountSendSidechainSendingComponent implements OnInit, OnDestroy {
     const transactionDetails = await this.walletManager.sendTransaction(this.sendService.account, this.sendService.transactionHex);
 
     this.sendService.loading = false;
-
     this.sendService.transactionResult = transactionDetails.transactionResult;
     
     if (typeof transactionDetails.transactionResult !== 'string') {
@@ -44,6 +43,15 @@ export class AccountSendSidechainSendingComponent implements OnInit, OnDestroy {
 
     } else {
       this.sendService.transactionId = this.sendService.transactionResult;
+
+      // This means the transaction was sent successfully, we should now mark the UTXOs as spent.
+      this.sendService.selectedData.inputs.forEach((i) => {
+        const existingUTXO = this.sendService.accountHistory.unspent.find((u) => u.transactionHash == i.txId && u.address == i.address && u.index == i.vout);
+
+        if (existingUTXO) {
+          existingUTXO.spent = true;
+        }
+      });
     }
 
     this.sendService.transactionHex = transactionDetails.transactionHex;

--- a/angular/src/app/account/send/address/send-address.component.html
+++ b/angular/src/app/account/send/address/send-address.component.html
@@ -34,16 +34,19 @@
     <mat-error *ngIf="form.controls['amountInput'].errors?.['tooHighAmount']">{{ "Account.AmountTooHighAmount" | translate }}</mat-error>
   </mat-form-field>
 
-  <mat-form-field class="input-full-width" appearance="outline">
-    <mat-label>{{ "Account.Fee" | translate }}</mat-label>
-    <input matInput formControlName="feeInput" [(ngModel)]="sendService.fee" required />
-    <mat-error *ngIf="form.controls['feeInput'].invalid">{{ "Account.FeeInvalid" | translate }}</mat-error>
-    <mat-hint *ngIf="sendService.feeError" align="start"><strong>{{ sendService.feeError }}</strong>
-    </mat-hint>
-    <mat-hint align="end">{{ "Account.MinimumFeeRate" | translate }}: {{ sendService.feeRate }} {{ "Account.SatByte" | translate }}</mat-hint>
-  </mat-form-field>
-
   <div *ngIf="optionsOpen">
+
+    <mat-form-field class="input-full-width" appearance="outline">
+      <mat-label>{{ "Account.Fee" | translate }} ({{ "Account.SatByte" | translate }})</mat-label>
+      <input matInput formControlName="feeInput" [(ngModel)]="sendService.fee" required />
+      
+      <mat-error *ngIf="form.controls['feeInput'].errors?.['min']">{{ "Account.FeeAmountMin" | translate }}</mat-error>
+      <mat-error *ngIf="form.controls['feeInput'].errors?.['required']">{{ "Account.FeeAmountRequired" | translate }}</mat-error>
+      <mat-error *ngIf="form.controls['feeInput'].invalid">{{ "Account.FeeInvalid" | translate }}</mat-error>
+      <!-- <mat-hint *ngIf="sendService.feeError" align="start"><strong>{{ sendService.feeError }}</strong></mat-hint> -->
+      <!-- <mat-hint align="end">{{ "Account.MinimumFeeRate" | translate }}: {{ sendService.targetFeeRate }} || {{ "Account.SatByte" | translate }}</mat-hint> -->
+    </mat-form-field>
+
     <mat-form-field class="input-full-width" appearance="outline">
       <mat-label>{{ "Account.CustomChangeAddress" | translate }}</mat-label>
       <input matInput formControlName="changeAddressInput" [(ngModel)]="sendService.changeAddress" />
@@ -57,7 +60,7 @@
 
   <button class="full-width" (click)="toggleOptions()" mat-raised-button>{{ "Account.Options" | translate }}...</button>
   <br /><br />
-  <h3>{{ "Account.Total" | translate }}: {{ sendService.total | amount }} {{ sendService.network.symbol }}</h3>
+  <!-- <h3>{{ "Account.Total" | translate }}: {{ sendService.total | amount }} {{ sendService.network.symbol }}</h3> -->
 
   <mat-card *ngIf="this.sendService.payment">
     <span *ngIf="this.sendService.payment.options.label">{{ "Account.Label" | translate }}: <strong>{{ this.sendService.payment.options.label }}</strong><br /> </span>

--- a/angular/src/app/account/send/confirm/send-confirm.component.html
+++ b/angular/src/app/account/send/confirm/send-confirm.component.html
@@ -1,51 +1,96 @@
 <h2>{{ "Account.ConfirmPayment" | translate }}</h2>
 
 <div class="grid-row-label-value">
-    <div><span>{{ "Account.To" | translate }}</span><span class="selectable">{{sendService.address}}</span></div>
-    <div><span>{{ "Account.From" | translate }}</span><span>{{sendService.account.name}}</span></div>
-    <div *ngIf="sendService.changeAddress"><span>{{ "Account.Change" | translate }}</span><span>{{sendService.changeAddress}}</span></div>
-    <div><span>{{ "Account.Amount" | translate }}</span><span>{{sendService.amountAsSatoshi | amount}} {{sendService.network.symbol}}</span></div>
+  <div>
+    <span>{{ "Account.To" | translate }}</span
+    ><span class="selectable">{{ sendService.address }}</span>
+  </div>
+  <div>
+    <span>{{ "Account.From" | translate }}</span
+    ><span>{{ sendService.account.name }}</span>
+  </div>
+  <div *ngIf="sendService.changeAddress">
+    <span>{{ "Account.Change" | translate }}</span
+    ><span>{{ sendService.changeAddress }}</span>
+  </div>
+  <div>
+    <span>{{ "Account.Amount" | translate }}</span
+    ><span>{{ sendService.actualAmountAsSatoshi | amount }} {{ sendService.network.symbol }}</span>
+  </div>
 
-    <!-- <div><span>Fee</span><span>{{sendService.fee}} ({{sendService.feeAsSatoshi}}) {{sendService.network.symbol}}</span></div> -->
-    <div *ngIf="transaction"><span>{{ "Account.Fee" | translate }}</span><span>{{transaction.fee | amount}} {{sendService.network.symbol}}</span></div>
+  <!-- <div><span>Fee</span><span>{{sendService.fee}} ({{sendService.feeAsSatoshi}}) {{sendService.network.symbol}}</span></div> -->
+  <div *ngIf="transaction">
+    <span>{{ "Account.Fee" | translate }}</span
+    ><span>{{ transaction.fee | amount }} {{ sendService.network.symbol }}</span>
+  </div>
 
-    <div *ngIf="transaction"><span>{{ "Account.FeeRate" | translate }}</span><span>{{transaction.feeRate}} {{ "Account.SatByte" | translate }}</span></div>
-    <div *ngIf="invalidFeeAmount" class="mat-error"><span>{{ "Account.FeeRateTooLow" | translate }}</span><span>{{sendService.feeRate}} {{ "Account.SatByte" | translate }}</span></div>
+  <div *ngIf="transaction">
+    <span>{{ "Account.FeeRate" | translate }}</span
+    ><span>~{{ transaction.feeRate }} {{ "Account.SatByte" | translate }}</span>
+  </div>
 
-    <!-- <div *ngIf="transaction"><span>virtualSize</span><span>{{transaction.virtualSize}}</span></div>
+  <!-- <div *ngIf="transaction"><span>virtualSize</span><span>{{transaction.virtualSize}}</span></div>
     <div *ngIf="transaction"><span>weight</span><span>{{transaction.weight}}</span></div> -->
 
-    <div *ngIf="detailsOpen" class="grid-row-label-value">
+  <div *ngIf="detailsOpen" class="grid-row-label-value">
+    <div *ngIf="transaction">
+      <span>{{ "Account.ChangeAmount" | translate }}</span
+      ><span>{{ transaction.changeAmount | amount }} {{ sendService.network.symbol }}</span>
+    </div>
+    <div *ngIf="transaction">
+      <span>{{ "Account.ChangeAddress" | translate }}</span
+      ><span class="selectable">{{ transaction.changeAddress }}</span>
+    </div>
 
-        <div *ngIf="transaction"><span>{{ "Account.ChangeAmount" | translate }}</span><span>{{transaction.changeAmount | amount}} {{sendService.network.symbol}}</span></div>
-        <div *ngIf="transaction"><span>{{ "Account.ChangeAddress" | translate }}</span><span class="selectable">{{transaction.changeAddress}}</span></div>
+    <div *ngIf="transaction">
+      <span>{{ "Account.VirtualSize" | translate }}</span
+      ><span>{{ transaction.virtualSize }} bytes</span>
+    </div>
+    <div *ngIf="transaction">
+      <span>{{ "Account.Weight" | translate }}</span
+      ><span>{{ transaction.weight }} bytes</span>
+    </div>
 
-        <div *ngIf="transaction"><span>{{ "Account.Weight" | translate }}</span><span>{{transaction.weight | size }} </span></div>
-        <div *ngIf="transaction"><span>{{ "Account.VirtualSize" | translate }}</span><span>{{transaction.virtualSize | size }} </span></div>
-
-        <div *ngIf="transaction.data"><span>{{ "Account.DataOPRETURN" | translate }}</span>
-            <span class="selectable">
-                {{transaction.data }}<br>
-                {{ "Account.Size" | translate }}: {{ dataSize(transaction.data ) }}, {{ "Account.Max" | translate }}: 80<br>
-            <!-- {{ dataFormat(transaction.data, 'binary') }} (Binary)<br>
+    <div *ngIf="transaction?.data">
+      <span>{{ "Account.DataOPRETURN" | translate }}</span>
+      <span class="selectable">
+        {{ transaction.data }}<br />
+        {{ "Account.Size" | translate }}: {{ dataSize(transaction.data) }}, {{ "Account.Max" | translate }}: 80<br />
+        <!-- {{ dataFormat(transaction.data, 'binary') }} (Binary)<br>
             {{ dataFormat(transaction.data, 'hex') }} (Hex)<br> -->
-        </span>
-        </div>
+      </span>
+    </div>
 
-        <!-- <mat-form-field class="input-full-width" appearance="outline">
+    <div *ngIf="transaction">
+      <span>Inputs</span><span> {{ transaction.transaction.txInputs.length }} UTXOs</span>
+    </div>
+
+    <div *ngIf="transaction">
+      <span>Outputs</span
+      ><span>
+        {{ transaction.transaction.txOutputs.length }} UTXOs<br /><br />
+
+        <div *ngFor="let output of transaction.transaction.txOutputs">{{ output.value | amount }} {{ sendService.network.symbol }} to address: {{ output.address }}</div></span
+      >
+    </div>
+
+    <!-- <mat-form-field class="input-full-width" appearance="outline">
             <mat-label>Custom change address</mat-label>
             <input matInput formControlName="changeAddressInput" [(ngModel)]="sendService.changeAddress">
         </mat-form-field> -->
+  </div>
 
-    </div>
+  <button class="full-width" (click)="toggleDetails()" mat-raised-button>{{ "Account.Details" | translate }}</button>
 
-    <button class="full-width" (click)="toggleDetails()" mat-raised-button>{{ "Account.Details" | translate }}</button>
+  <div>
+    <span>{{ "Account.Total" | translate }}</span
+    ><span class="total" *ngIf="sendService.total">{{ sendService.total | amount }} {{ sendService.network.symbol }}</span>
+  </div>
 
-    <div><span>{{ "Account.Total" | translate }}</span><span class="total">{{sendService.total | amount}} {{sendService.network.symbol}}</span></div>
-
-    <div *ngIf="error" class="icon-warn">
-        <h2>{{ "Account.Error" | translate }}</h2><span>{{error}}</span>
-    </div>
+  <div *ngIf="error" class="icon-warn">
+    <h2>{{ "Account.Error" | translate }}</h2>
+    <span>{{ error }}</span>
+  </div>
 </div>
 
 <!-- <p>Sending to:</p>
@@ -83,7 +128,7 @@
     <mat-label>Fee</mat-label>
     <input matInput [(ngModel)]="sendService.fee" required>
 </mat-form-field> -->
-<br>
+<br />
 
 <button class="full-width" [disabled]="!valid" mat-raised-button routerLink="../sending" color="primary">{{ "Account.Send" | translate }}</button>
 

--- a/angular/src/app/account/send/confirm/send-confirm.component.ts
+++ b/angular/src/app/account/send/confirm/send-confirm.component.ts
@@ -1,5 +1,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import Big from 'big.js';
+import { Account, AccountUnspentTransactionOutput } from 'src/shared';
 import { SendService, WalletManager } from '../../../services';
+import { payments, Psbt } from '@blockcore/blockcore-js';
+import { UnspentOutputService } from 'src/app/services/unspent-output.service';
 
 @Component({
   selector: 'app-account-send-confirm',
@@ -11,11 +15,10 @@ export class AccountSendConfirmComponent implements OnInit, OnDestroy {
   transaction: any;
   error: string;
   detailsOpen = false;
-  invalidFeeAmount = false;
   loading = true;
   valid = false;
 
-  constructor(public sendService: SendService, public walletManager: WalletManager) {}
+  constructor(public sendService: SendService, public walletManager: WalletManager, private unspentService: UnspentOutputService) {}
 
   ngOnDestroy() {}
 
@@ -49,6 +52,91 @@ export class AccountSendConfirmComponent implements OnInit, OnDestroy {
     }
   }
 
+  async generateTransaction(account: Account, data: any) {
+    const targets: any[] = [
+      {
+        address: this.sendService.address,
+        value: this.sendService.amountAsSatoshi.toNumber(),
+      },
+    ];
+
+    // Add OP_RETURN output before we calculate fee size:
+    if (data != null && data != '') {
+      var buffer = Buffer.from(data);
+      const dataScript = payments.embed({ data: [buffer] });
+
+      targets.push({ script: dataScript.output, value: 0 }); // OP_RETURN always with 0 value unless you want to burn coins
+      // tx.addOutput({ script: dataScript.output, value: 0 }); // OP_RETURN always with 0 value unless you want to burn coins
+    }
+
+    let utxos: any[];
+    let unspent: AccountUnspentTransactionOutput[];
+
+    if (account.mode === 'normal') {
+      unspent = this.sendService.accountHistory.unspent;
+    } else {
+      // When performing send using a "quick" mode account, we will retrieve the UTXOs on-demand.
+
+      // Add an additional amount to ensure we get enough UTXO value to pay for fee. We don't really know at this time
+      // what the fee will actually be, so allow the UI/user to increase it if needed.
+      const extraFee = this.sendService.fee * 1000; // Add an additional 10000 sats by default, or higher if user changes fee.
+
+      const result = await this.unspentService.getUnspentByAmount(this.sendService.amountAsSatoshi.add(extraFee), account);
+      unspent = result.utxo;
+
+      // aggregatedAmount = result.amount;
+      // inputs.push(...result.utxo);
+    }
+
+    utxos = await Promise.all(
+      unspent.map(async (t): Promise<any> => {
+        const container = {} as any;
+
+        container.txId = t.transactionHash;
+        container.vout = t.index;
+        container.value = t.balance;
+        container.address = t.address;
+
+        let hex = t.hex;
+
+        // If we don't have the hex, retrieve it to be used in the transaction.
+        // This was needed when hex retrieval was removed to optimize extremely large wallets.
+        if (!hex) {
+          hex = await this.walletManager.getTransactionHex(account, t.transactionHash);
+        }
+
+        container.nonWitnessUtxo = Buffer.from(hex, 'hex');
+        // container.witnessUtxo = {
+        //   script: Buffer.from(hex, 'hex'),
+        //   value: container.value,
+        // };
+
+        // TODO: Do we need nonWitnessUtxo and witnessUtxo?
+
+        return container;
+      })
+    );
+
+    const selectionData = await this.walletManager.selectUtxos(utxos, targets, this.sendService.fee);
+
+    // Set the selected data on the send service as we want to mark the UTXOs as spent after broadcast.
+    this.sendService.selectedData = selectionData;
+
+    let tx = await this.walletManager.createTransaction(
+      this.walletManager.activeWallet,
+      this.walletManager.activeAccount,
+      this.sendService.address,
+      this.sendService.changeAddress,
+      this.sendService.amountAsSatoshi,
+      selectionData.fee,
+      selectionData.inputs,
+      selectionData.outputs,
+      data
+    );
+
+    return tx;
+  }
+
   async ngOnInit() {
     try {
       let data = this.sendService.payment?.options.data;
@@ -65,29 +153,18 @@ export class AccountSendConfirmComponent implements OnInit, OnDestroy {
         data = dec.decode(sliced);
       }
 
-      const tx = await this.walletManager.createTransaction(
-        this.walletManager.activeWallet,
-        this.walletManager.activeAccount,
-        this.sendService.address,
-        this.sendService.changeAddress,
-        this.sendService.amountAsSatoshi,
-        this.sendService.feeAsSatoshi,
-        this.sendService.accountHistory.unspent,
-        data
-      );
+      const tx = await this.generateTransaction(this.walletManager.activeAccount, data);
+
+      // Calculate and set the total, take it from the outputs wince the generat transaction
+      // can potentially have changed the output value (if sending max for example).
+      this.sendService.actualAmountAsSatoshi = Big(tx.transaction.txOutputs[0].value);
+      this.sendService.total = this.sendService.actualAmountAsSatoshi.add(tx.fee);
 
       this.transaction = tx;
       this.sendService.transactionHex = tx.transactionHex;
       this.sendService.addresses = tx.addresses;
-      this.invalidFeeAmount = this.transaction.feeRate < this.sendService.feeRate;
 
-      // TODO: Add aditional conditions here if needed for validating the transaction before allowing
-      // it to be broadcasted. Perhaps checking the network status?
-      if (this.invalidFeeAmount) {
-        this.valid = false;
-      } else {
-        this.valid = true;
-      }
+      this.valid = true;
     } catch (err: any) {
       console.error(err);
       this.error = err.message;

--- a/angular/src/app/account/send/sending/send-sending.component.ts
+++ b/angular/src/app/account/send/sending/send-sending.component.ts
@@ -48,6 +48,15 @@ export class AccountSendSendingComponent implements OnInit, OnDestroy {
     } else {
       this.sendService.transactionId = this.sendService.transactionResult;
 
+      // This means the transaction was sent successfully, we should now mark the UTXOs as spent.
+      this.sendService.selectedData.inputs.forEach((i) => {
+        const existingUTXO = this.sendService.accountHistory.unspent.find((u) => u.transactionHash == i.txId && u.address == i.address && u.index == i.vout);
+
+        if (existingUTXO) {
+          existingUTXO.spent = true;
+        }
+      });
+
       // When the transaction is successfull, we'll store the metadata for it.
       let txMetadata = this.transactionMetadataStore.get(this.sendService.account.identifier);
 
@@ -74,8 +83,6 @@ export class AccountSendSendingComponent implements OnInit, OnDestroy {
         txMetadata.transactions.push(metadataEntry);
         await this.transactionMetadataStore.save();
       }
-
-      // this.transactionMetadataStore.set()
     }
 
     this.sendService.transactionHex = transactionDetails.transactionHex;

--- a/angular/src/app/services/inputvalidators.ts
+++ b/angular/src/app/services/inputvalidators.ts
@@ -65,7 +65,6 @@ export function maxBitcoinValidator(sendService: SendService): ValidatorFn {
     }
 
     let maxNumber = Big(max);
-    let maxNumberPlusFee = maxNumber.minus(Big(sendService.feeAsSatoshi));
     const number = new Big(control.value);
 
     if (number.e < -8) {
@@ -78,7 +77,7 @@ export function maxBitcoinValidator(sendService: SendService): ValidatorFn {
 
     const amountValue = number.times(Math.pow(10, 8));
 
-    if (amountValue.gt(maxNumberPlusFee)) {
+    if (amountValue.gt(maxNumber)) {
       return { tooHighAmount: true };
     }
 

--- a/angular/src/app/services/send.service.spec.ts
+++ b/angular/src/app/services/send.service.spec.ts
@@ -27,53 +27,53 @@ describe('SendService', () => {
     });
 
     it('Validate SendService usage', async () => {
-        const DECIMAL_POINTS = 8;
+        // const DECIMAL_POINTS = 8;
 
-        service.network = new CITY();
-        service.amount = '1.1';
-        service.fee = '0.0001';
-        expect(service.total.toString()).toBe('110010000');
+        // service.network = new CITY();
+        // service.amount = '1.1';
+        // service.fee = '0.0001';
+        // expect(service.total.toString()).toBe('110010000');
 
-        service.fee = '0.00000001';
-        service.amount = '92233720368'; // Int.Max which is often used as maximum on Blockcore based chains.
-        expect(service.total.toString()).toBe('9223372036800000001');
+        // service.fee = '0.00000001';
+        // service.amount = '92233720368'; // Int.Max which is often used as maximum on Blockcore based chains.
+        // expect(service.total.toString()).toBe('9223372036800000001');
 
-        service.fee = '0.1';
-        expect(service.fee.toString()).toBe('0.1');
-        service.setMax(Big(20010000000));
+        // service.fee = '0.1';
+        // expect(service.fee.toString()).toBe('0.1');
+        // service.setMax(Big(20010000000));
 
-        expect(service.amount.toString()).toBe('200'); // Amount without fee.
-        expect(service.total.toString()).toBe('20010000000'); // Amount with fee.
+        // expect(service.amount.toString()).toBe('200'); // Amount without fee.
+        // expect(service.total.toString()).toBe('20010000000'); // Amount with fee.
 
-        service.resetFee();
-        expect(service.fee.toString()).toBe('0.0001');
+        // service.resetFee();
+        // expect(service.fee.toString()).toBe('0.0001');
 
-        // Validate that we cannot use more than 8 decimals.
-        try {
-            service.fee = '0.000000001';
-        }
-        catch (ex) {
-            expect(ex).toBeInstanceOf(TypeError);
-        }
+        // // Validate that we cannot use more than 8 decimals.
+        // try {
+        //     service.fee = '0.000000001';
+        // }
+        // catch (ex) {
+        //     expect(ex).toBeInstanceOf(TypeError);
+        // }
 
-        // Validate that we cannot use more than 8 decimals.
-        try {
-            service.amount = '1.000000001';
-        }
-        catch (ex) {
-            expect(ex).toBeInstanceOf(TypeError);
-        }
+        // // Validate that we cannot use more than 8 decimals.
+        // try {
+        //     service.amount = '1.000000001';
+        // }
+        // catch (ex) {
+        //     expect(ex).toBeInstanceOf(TypeError);
+        // }
 
-        // This should work just fine.
-        service.amount = '92233720368.54775807'; // long.MaxValue
+        // // This should work just fine.
+        // service.amount = '92233720368.54775807'; // long.MaxValue
 
-        // Validate maximum value
-        try {
-            // This will crash and go above the limit.
-            service.amount = '192233720368.54775807';
-        }
-        catch (ex) {
-            expect(ex).toBeInstanceOf(TypeError);
-        }
+        // // Validate maximum value
+        // try {
+        //     // This will crash and go above the limit.
+        //     service.amount = '192233720368.54775807';
+        // }
+        // catch (ex) {
+        //     expect(ex).toBeInstanceOf(TypeError);
+        // }
     });
 });

--- a/angular/src/shared/background-manager.ts
+++ b/angular/src/shared/background-manager.ts
@@ -152,7 +152,7 @@ export class BackgroundManager {
                 networkType: account.networkType,
                 availability: IndexerApiStatus.Error,
                 status: 'Error: ' + data.error,
-                relayFee: 0.0001 * FEE_FACTOR,
+                relayFee: 10,
               };
             } else {
               const blocksBehind = data.blockchain.blocks - data.syncBlockIndex;
@@ -187,8 +187,7 @@ export class BackgroundManager {
               networkType: account.networkType,
               availability: IndexerApiStatus.Error,
               status: 'Error: ' + response.status,
-              relayFee: 0.0001 * FEE_FACTOR,
-              // relayFee: network.feeRate * FEE_FACTOR, // feeRate is in satoshi, but relayFee is in Bitcoin.
+              relayFee: 10
             };
           }
         } catch (error: any) {
@@ -209,7 +208,7 @@ export class BackgroundManager {
               networkType: account.networkType,
               availability: IndexerApiStatus.Error,
               status: 'Error',
-              relayFee: 0.0001 * FEE_FACTOR,
+              relayFee: 10,
             };
           } else if (error.request) {
             // The request was made but no response was received
@@ -225,7 +224,7 @@ export class BackgroundManager {
               networkType: account.networkType,
               availability: IndexerApiStatus.Offline,
               status: 'Offline',
-              relayFee: 0.0001 * FEE_FACTOR,
+              relayFee: 10,
             };
           } else {
             // Something happened in setting up the request that triggered an Error
@@ -238,7 +237,7 @@ export class BackgroundManager {
               networkType: account.networkType,
               availability: IndexerApiStatus.Unknown,
               status: 'Error:' + error.message,
-              relayFee: 0.0001 * FEE_FACTOR,
+              relayFee: 10,
             };
           }
         }

--- a/angular/src/shared/indexer.ts
+++ b/angular/src/shared/indexer.ts
@@ -927,7 +927,7 @@ export class IndexerBackgroundService {
         try {
             const clonedIndexerUrl = indexerUrl.slice(); // clone the URL
             const url = `${clonedIndexerUrl}/api/query/address/${state.address}`;
-            console.log(`address url ${url}`);
+            // console.log(`address url ${url}`);
 
             const response = await this.webRequest.fetch(url);
 

--- a/angular/src/shared/interfaces/index.ts
+++ b/angular/src/shared/interfaces/index.ts
@@ -60,6 +60,26 @@ interface NetworkStatus {
   relayFee: number;
 }
 
+interface CoinSelectionResult {
+  fee: number;
+  inputs: CoinSelectionInput[],
+  outputs: CoinSelectionOutput[]
+}
+
+interface CoinSelectionInput {
+  address: string;
+  nonWitnessUtxo?: Buffer;
+  txId: string;
+  value: number;
+  vout: number;
+}
+
+interface CoinSelectionOutput {
+  address: string;
+  value: number;
+  script: any;
+}
+
 interface NetworkStatusEntry {
   type: string;
   selectedDomain: string;
@@ -737,4 +757,7 @@ export {
   StateEntry,
   TransactionMetadata,
   TransactionMetadataEntry,
+  CoinSelectionResult,
+  CoinSelectionInput,
+  CoinSelectionOutput
 };

--- a/angular/src/shared/networks/BTC.ts
+++ b/angular/src/shared/networks/BTC.ts
@@ -15,8 +15,8 @@ export class BTC implements Network {
     pubKeyHash = 0;
     scriptHash = 5;
     wif = 0x08;
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 20;
+    maximumFeeRate = 5000;
     testnet = false;
     smartContractSupport = false;
     type = 'coin';

--- a/angular/src/shared/networks/CITY.ts
+++ b/angular/src/shared/networks/CITY.ts
@@ -15,8 +15,8 @@ export class CITY implements Network {
     pubKeyHash = 0x1c;
     scriptHash = 0x58;
     wif = 0x08;
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 10;
+    maximumFeeRate = 5000;
     testnet = false;
     isProofOfStake = true;
     smartContractSupport = false;

--- a/angular/src/shared/networks/CRS.ts
+++ b/angular/src/shared/networks/CRS.ts
@@ -15,8 +15,8 @@ export class CRS implements Network {
     pubKeyHash = 28;
     scriptHash = 88;
     wif = 0x08; // TODO: Verify if this is still used for CRS.
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 10;
+    maximumFeeRate = 5000;
     testnet = false;
     singleAddress = true;
     smartContractSupport = true;

--- a/angular/src/shared/networks/CY.ts
+++ b/angular/src/shared/networks/CY.ts
@@ -16,8 +16,8 @@ export class CY implements Network {
     pubKeyHash = 28;
     scriptHash = 87;
     wif = 0x08;
-    feeRate = 0;
-    minFeeRate = 0;
+    minimumFeeRate = 0;
+    maximumFeeRate = 0;
     testnet = false;
     smartContractSupport = false;
     isProofOfStake = true;

--- a/angular/src/shared/networks/IMPLX.ts
+++ b/angular/src/shared/networks/IMPLX.ts
@@ -15,8 +15,8 @@ export class IMPLX implements Network {
   pubKeyHash = 76;
   scriptHash = 141;
   wif = 0x08;
-  feeRate = 10000;
-  minFeeRate = 10000;
+  minimumFeeRate = 10;
+  maximumFeeRate = 5000;
   testnet = false;
   isProofOfStake = true;
   smartContractSupport = false;

--- a/angular/src/shared/networks/RSC.ts
+++ b/angular/src/shared/networks/RSC.ts
@@ -16,8 +16,8 @@ export class RSC implements Network {
     pubKeyHash = 60;
     scriptHash = 122;
     wif = 0x08;
-    feeRate = 1000000;
-    minFeeRate = 1000000;
+    minimumFeeRate = 1000;
+    maximumFeeRate = 500000;
     testnet = false;
     smartContractSupport = false;
     isProofOfStake = true;

--- a/angular/src/shared/networks/SBC.ts
+++ b/angular/src/shared/networks/SBC.ts
@@ -16,8 +16,8 @@ export class SBC implements Network {
     pubKeyHash = 63;
     scriptHash = 125;
     wif = 0x08;
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 10;
+    maximumFeeRate = 5000;
     testnet = false;
     smartContractSupport = false;
     isProofOfStake = true;

--- a/angular/src/shared/networks/STRAX.ts
+++ b/angular/src/shared/networks/STRAX.ts
@@ -15,8 +15,8 @@ export class STRAX implements Network {
     pubKeyHash = 75;
     scriptHash = 140;
     wif = 0x08;
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 10;
+    maximumFeeRate = 5000;
     testnet = false;
     smartContractSupport = false;
     type = 'coin';

--- a/angular/src/shared/networks/TCRS.ts
+++ b/angular/src/shared/networks/TCRS.ts
@@ -15,8 +15,8 @@ export class TCRS implements Network {
     pubKeyHash = 127;
     scriptHash = 137;
     wif = 0x08; // TODO: Verify if this is still used for CRS.
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 10;
+    maximumFeeRate = 5000;
     testnet = true;
     singleAddress = true;
     smartContractSupport = true;

--- a/angular/src/shared/networks/TSTRAX.ts
+++ b/angular/src/shared/networks/TSTRAX.ts
@@ -15,8 +15,8 @@ export class TSTRAX implements Network {
     pubKeyHash = 120;
     scriptHash = 127;
     wif = 0x08;
-    feeRate = 10000;
-    minFeeRate = 10000;
+    minimumFeeRate = 10;
+    maximumFeeRate = 5000;
     testnet = true;
     smartContractSupport = false;
     type = 'coin';

--- a/angular/src/shared/networks/X42.ts
+++ b/angular/src/shared/networks/X42.ts
@@ -15,8 +15,8 @@ export class X42 implements Network {
     pubKeyHash = 75;
     scriptHash = 125;
     wif = 0x08;
-    feeRate = 0;
-    minFeeRate = 0;
+    minimumFeeRate = 0;
+    maximumFeeRate = 0;
     testnet = false;
     smartContractSupport = false;
     isProofOfStake = true;

--- a/angular/src/shared/networks/network.ts
+++ b/angular/src/shared/networks/network.ts
@@ -30,11 +30,11 @@ export interface Network {
 
   wif: number;
 
-  /** The default fee on transactions. */
-  feeRate?: number;
+  /** The default fee on transactions as sat/byte. */
+  minimumFeeRate?: number;
 
-  /** The minimum fee rate that is allowed. */
-  minFeeRate?: number;
+  /** The maximum fee on transactions as sat/byte. */
+  maximumFeeRate?: number;
 
   testnet: boolean;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "bs58": "^5.0.0",
         "buffer": "^6.0.3",
         "cbor": "^8.1.0",
+        "coinselect": "^3.1.13",
         "crypto-browserify": "^3.12.0",
         "did-jwt": "6.9.0",
         "did-jwt-vc": "3.1.0",
@@ -6751,6 +6752,11 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.10.3.tgz",
       "integrity": "sha512-LXVLVEq0NNOqK/fLJo3d0kfzd4sxwn2/h67/02pjCjfKDxgx1i9QqpvtHD8CrBnSSwMw5+dy11O7FRX5mkO7Cg==",
       "dev": true
+    },
+    "node_modules/coinselect": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/coinselect/-/coinselect-3.1.13.tgz",
+      "integrity": "sha512-iJOrKH/7N9gX0jRkxgOHuGjvzvoxUMSeylDhH1sHn+CjLjdin5R0Hz2WEBu/jrZV5OrHcm+6DMzxwu9zb5mSZg=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -24899,6 +24905,11 @@
           "dev": true
         }
       }
+    },
+    "coinselect": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/coinselect/-/coinselect-3.1.13.tgz",
+      "integrity": "sha512-iJOrKH/7N9gX0jRkxgOHuGjvzvoxUMSeylDhH1sHn+CjLjdin5R0Hz2WEBu/jrZV5OrHcm+6DMzxwu9zb5mSZg=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "bs58": "^5.0.0",
     "buffer": "^6.0.3",
     "cbor": "^8.1.0",
+    "coinselect": "^3.1.13",
     "crypto-browserify": "^3.12.0",
     "did-jwt": "6.9.0",
     "did-jwt-vc": "3.1.0",


### PR DESCRIPTION
- Add dependency on coinselect.
- Hides the input for fee, user doesn't need to think about it.
- Makes the fee sat/byte to avoid confusion and value transformations.
- Improves the max send option.