### PR TITLE
NIP-76: Private Channels - Draft 2 - Includes Client Implementation and Tool kit library 

### DIFF
--- a/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.css
+++ b/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.css
@@ -1,0 +1,3 @@
+.signing-content {
+    height: 120px;
+}

--- a/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.html
+++ b/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.html
@@ -6,9 +6,4 @@
     {{ "Action.Account" | translate }}: {{walletManager.activeAccount?.name}}<br>
     {{ "Action.DerivationPath" | translate }}: {{networkService.getDerivationPathForAccount(walletManager.activeAccount)}}<br><br>
 
-    <button (click)="createPrivateChannelAccount()">Create Account</button>
-    <!-- <mat-form-field class="input-full-width" appearance="outline">
-        <mat-label>{{ "Action.SigningContentLabel" | translate }}</mat-label>
-        <textarea class="signing-content" matInput [ngModel]="mnemonic"></textarea>
-    </mat-form-field> -->
 </div>

--- a/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.html
+++ b/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.html
@@ -1,0 +1,14 @@
+<div class="page">
+    {{ "Action.AttestContentDescription" | translate }}:
+    <br><br>
+
+    {{ "Action.Wallet" | translate }}: {{walletManager.activeWallet?.name}}<br>
+    {{ "Action.Account" | translate }}: {{walletManager.activeAccount?.name}}<br>
+    {{ "Action.DerivationPath" | translate }}: {{networkService.getDerivationPathForAccount(walletManager.activeAccount)}}<br><br>
+
+    <button (click)="createPrivateChannelAccount()">Create Account</button>
+    <!-- <mat-form-field class="input-full-width" appearance="outline">
+        <mat-label>{{ "Action.SigningContentLabel" | translate }}</mat-label>
+        <textarea class="signing-content" matInput [ngModel]="mnemonic"></textarea>
+    </mat-form-field> -->
+</div>

--- a/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.ts
+++ b/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.ts
@@ -1,0 +1,76 @@
+import { Component, ChangeDetectorRef, ApplicationRef, NgZone, OnInit } from '@angular/core';
+import { CryptoService, UIState, NetworksService, CommunicationService, AppManager, WalletManager } from '../../services';
+import { Router } from '@angular/router';
+import { ActionService } from '../../services/action.service';
+import { TranslateService } from '@ngx-translate/core';
+import { nostrPrivateChannelAccountName } from '../../../shared/handlers/nostr-nip76-wallet-handler';
+const { v4: uuidv4 } = require('uuid');
+
+@Component({
+  selector: 'app-nostr-nip76-root',
+  templateUrl: './nostr-nip76-root.component.html',
+  styleUrls: ['./nostr-nip76-root.component.css']
+})
+export class ActionNostrNip76RootComponent implements OnInit {
+  content?: string;
+  parameters?: any;
+  expiryDate: Date;
+  callback: string;
+  result: string;
+  success?: boolean;
+  mnemonic: string;
+
+  constructor(
+    public uiState: UIState,
+    private crypto: CryptoService,
+    private router: Router,
+    private app: ApplicationRef,
+    private actionService: ActionService,
+    private ngZone: NgZone,
+    private communication: CommunicationService,
+    public networkService: NetworksService,
+    public walletManager: WalletManager,
+    private manager: AppManager,
+    private cd: ChangeDetectorRef,
+    public translate: TranslateService) {
+
+      this.actionService.status.title = 'Create an HDK Index Wallet';
+      this.actionService.status.description = 
+        `Creates a separate NIP-76 Hierarchical Deterministic Key Wallet Root used for indexing and encrypting Nostr Events.`;
+      this.actionService.consentType = 'regular';
+      this.actionService.permissionLevel = 'account';
+      // this.actionService.accountId = walletManager.activeAccountId;
+  }
+
+  ngOnDestroy(): void {
+
+  }
+
+  async ngOnInit() {
+    const accountTranslate = await this.translate.get('Account.Account').toPromise();
+    this.uiState.title = accountTranslate + ': ' + this.walletManager.activeAccount?.name;
+    this.mnemonic = this.crypto.generateMnemonic();
+    // this.createPrivateChannelAccount();
+  }
+
+  async createPrivateChannelAccount() {
+    let account = this.walletManager.activeWallet.accounts.find(x => x.name === nostrPrivateChannelAccountName);
+    if (!account) {
+      account = {
+        identifier: uuidv4(),
+        type: 'identity',
+        mode: 'normal',
+        singleAddress: true,
+        networkType: 'NOSTR',
+        name: nostrPrivateChannelAccountName,
+        index: 1776,
+        network: 1237,
+        purpose: 44,
+        purposeAddress: 340,
+        icon: 'account_circle',
+      };
+      await this.walletManager.addAccount(account, this.walletManager.activeWallet);
+    }
+    this.actionService.accountId = account.identifier;
+  }
+}

--- a/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.ts
+++ b/angular/src/app/action/nostr-nip76-root/nostr-nip76-root.component.ts
@@ -34,12 +34,11 @@ export class ActionNostrNip76RootComponent implements OnInit {
     private cd: ChangeDetectorRef,
     public translate: TranslateService) {
 
-      this.actionService.status.title = 'Create an HDK Index Wallet';
+      this.actionService.status.title = 'Use an HDK Index';
       this.actionService.status.description = 
-        `Creates a separate NIP-76 Hierarchical Deterministic Key Wallet Root used for indexing and encrypting Nostr Events.`;
+        `Uses a separate Hierarchical Deterministic Key on the Account used for signing, indexing and encrypting Nostr Events.`;
       this.actionService.consentType = 'regular';
       this.actionService.permissionLevel = 'account';
-      // this.actionService.accountId = walletManager.activeAccountId;
   }
 
   ngOnDestroy(): void {

--- a/angular/src/app/app-routing.module.ts
+++ b/angular/src/app/app-routing.module.ts
@@ -65,6 +65,7 @@ import { ActionNostrDecryptComponent } from './action/nostr.decrypt/nostr.decryp
 import { ActionTransactionSendComponent } from './action/transaction.send/transaction.send.component';
 import { ActionWalletUnlockComponent } from './action/wallet.unlock/wallet.unlock.component';
 import { ActionSwapsSendComponent } from './action/swaps.send/swaps.send.component';
+import { ActionNostrNip76RootComponent } from './action/nostr-nip76-root/nostr-nip76-root.component';
 
 const routes: Routes = [
   {
@@ -473,6 +474,41 @@ const routes: Routes = [
       {
         path: 'nostr.decrypt',
         component: ActionNostrDecryptComponent,
+        resolve: {
+          data: LoadingResolverService,
+        },
+      },
+      {
+        path: 'nostr.nip76.wallet',
+        component: ActionNostrNip76RootComponent,
+        resolve: {
+          data: LoadingResolverService,
+        },
+      },
+      {
+        path: 'nostr.nip76.event.create',
+        component: ActionNostrNip76RootComponent,
+        resolve: {
+          data: LoadingResolverService,
+        },
+      },
+      {
+        path: 'nostr.nip76.event.delete',
+        component: ActionNostrNip76RootComponent,
+        resolve: {
+          data: LoadingResolverService,
+        },
+      },
+      {
+        path: 'nostr.nip76.invite.read',
+        component: ActionNostrNip76RootComponent,
+        resolve: {
+          data: LoadingResolverService,
+        },
+      },
+      {
+        path: 'nostr.nip76.invite.create',
+        component: ActionNostrNip76RootComponent,
         resolve: {
           data: LoadingResolverService,
         },

--- a/angular/src/app/app.module.ts
+++ b/angular/src/app/app.module.ts
@@ -131,7 +131,7 @@ import { ActionTransactionSendComponent } from './action/transaction.send/transa
 import { SendConfirmationDialog } from './action/transaction.send/send-confirmation-dialog/send-confirmation-dialog';
 import { ActionWalletUnlockComponent } from './action/wallet.unlock/wallet.unlock.component';
 import { ActionSwapsSendComponent } from './action/swaps.send/swaps.send.component';
-
+import { ActionNostrNip76RootComponent } from './action/nostr-nip76-root/nostr-nip76-root.component';
 // required for AOT compilation
 export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
   return new TranslateHttpLoader(http);
@@ -216,6 +216,7 @@ export function HttpLoaderFactory(http: HttpClient): TranslateHttpLoader {
     SendConfirmationDialog,
     ActionWalletUnlockComponent,
     ActionSwapsSendComponent,
+    ActionNostrNip76RootComponent
   ],
   imports: [
     BrowserModule,

--- a/angular/src/shared/handlers/index.ts
+++ b/angular/src/shared/handlers/index.ts
@@ -20,6 +20,7 @@ import { SendTransactionHandler } from './send-transaction-handler';
 import { AtomicSwapsKeyHandler } from './atomic-swap-key-handler';
 import { AtomicSwapsSecretHandler } from './atomic-swap-secret-handler';
 import { AtomicSwapsSendHandler } from './atomic-swap-send-handler';
+import { NostrNip76WalletHandler } from './nostr-nip76-wallet-handler';
 
 // TODO: Make this more generic where the handlers are registered as form of factory.
 export class Handlers {
@@ -53,6 +54,14 @@ export class Handlers {
         return new NostrEncryptHandler(backgroundManager);
       case 'nostr.decrypt':
         return new NostrDecryptHandler(backgroundManager);
+      case 'nostr.nip76.wallet':
+      case 'nostr.nip76.event.create':
+      case 'nostr.nip76.event.delete':
+      case 'nostr.nip76.invite.read':
+      case 'nostr.nip76.invite.create':
+        const handler = new NostrNip76WalletHandler(backgroundManager);
+        handler.action = [action];
+        return handler;
       case 'transaction.send':
         return new SendTransactionHandler(backgroundManager);
       case 'atomicswaps.key':

--- a/angular/src/shared/handlers/nostr-nip76-wallet-handler.ts
+++ b/angular/src/shared/handlers/nostr-nip76-wallet-handler.ts
@@ -1,0 +1,86 @@
+import { BackgroundManager } from '../background-manager';
+import { Account, ActionPrepareResult, ActionResponse, Permission, Wallet } from '../interfaces';
+import { ActionHandler, ActionState } from './action-handler';
+import { validateEvent, signEvent, getEventHash, Event, getPublicKey } from 'nostr-tools';
+import { SigningUtilities } from '../identity/signing-utilities';
+import { sha512 } from '@noble/hashes/sha512';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
+import { HDKey } from '@scure/bip32';
+import { ContentDocument, ContentTemplate, HDKIndex, HDKey as Nip76HDKey, Versions, NostrEventDocument, nip19Extension } from 'animiq-nip76-tools';
+
+export const nostrPrivateChannelAccountName = 'Nostr Private Channels';
+
+export class NostrNip76WalletHandler implements ActionHandler {
+  action = ['nostr.nip76.wallet'];
+  utility = new SigningUtilities();
+
+  constructor(private backgroundManager: BackgroundManager) { }
+
+  async prepare(state: ActionState): Promise<ActionPrepareResult> {
+    return {
+      content: [],
+      consent: true,
+    };
+  }
+
+  async execute(state: ActionState, permission: Permission): Promise<ActionResponse> {
+    const profileKey = await this.getKey(permission, permission.keyId);
+    const key = getPublicKey(profileKey.privateKey as any);
+
+    switch (state.message.request.method) {
+      case 'nostr.nip76.wallet': {
+        const key0 = await this.getKey(permission, `1776'/0'`);
+        const rootKey = new Nip76HDKey({ privateKey: key0.privateKey, chainCode: key0.chainCode, version: Versions.nip76API1 });
+        const key1 = await this.getKey(permission, `1776'/1'`);
+        const wordsetKey = new Nip76HDKey({ privateKey: key1.privateKey, chainCode: key1.chainCode, version: Versions.nip76API1 });
+        const wordsetHash = sha512(wordsetKey.privateKey);
+        const wordset = new Uint32Array((wordsetHash).buffer);
+        const response = { key, rootKey, wordset };
+        return { key, response };
+      }
+      case 'nostr.nip76.event.create': {
+        const hdkIndex = HDKIndex.fromJSON(state.message.request.params[0]);
+        const serializedContent = state.message.request.params[1];
+        const kind = parseInt(serializedContent.match(/\d+/)![0]);
+        const doc = HDKIndex.getContentClass(kind);
+        doc.deserialize(serializedContent);
+        doc.content.pubkey = key;
+        doc.docIndex = state.message.request.params[2];
+        const event = await hdkIndex.createEvent(doc, bytesToHex(profileKey.privateKey));
+        const response = { key, event };
+        return { key, response };
+      }
+      case 'nostr.nip76.event.delete': {
+        const hdkIndex = HDKIndex.fromJSON(state.message.request.params[0]);
+        const doc = new ContentDocument();
+        doc.nostrEvent = { id: state.message.request.params[1] } as NostrEventDocument;
+        doc.docIndex = state.message.request.params[2];
+        const event = await hdkIndex.createDeleteEvent(doc, bytesToHex(profileKey.privateKey));
+        const response = { key, event };
+        return { key, response };
+      }
+      case 'nostr.nip76.invite.read': {
+        const channelPointer = state.message.request.params[0];
+        const p = await nip19Extension.decode(channelPointer, bytesToHex(profileKey.privateKey));
+        const pointer = nip19Extension.pointerToDTO(p.data as nip19Extension.PrivateChannelPointer);
+        const response = { key, pointer };
+        return { key, response };
+      }
+      case 'nostr.nip76.invite.create': {
+        const pointer: nip19Extension.PrivateChannelPointerDTO = state.message.request.params[0];
+        const forPubkey: string = state.message.request.params[1];
+        const channelPointer = nip19Extension.pointerFromDTO(pointer);
+        const invitation = await nip19Extension.nprivateChannelEncode(channelPointer, bytesToHex(profileKey.privateKey), forPubkey);
+        const response = { key, invitation };
+        return { key, response };
+      }
+      default:
+        throw new Error(`method '${state.message.request.method}' not recognized.`);
+    };
+  }
+
+  async getKey(permission: Permission, keyId: string) {
+    const { network, node } = await this.backgroundManager.getKey(permission.walletId, permission.accountId, keyId);
+    return node as HDKey;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@scure/bip39": "^1.1.1",
         "@tbd54566975/dwn-sdk-js": "^0.0.25",
         "@types/qs": "^6.9.7",
+        "animiq-nip76-tools": "file:../../animiq-nip76-tools/dist",
         "async-mutex": "^0.4.0",
         "axios": "0.27.2",
         "axios-retry": "^3.3.1",
@@ -4850,6 +4851,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/animiq-nip76-tools": {
+      "version": "1.0.5",
+      "resolved": "file:../../animiq-nip76-tools/dist",
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -22581,6 +22587,9 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "requires": {}
+    },
+    "animiq-nip76-tools": {
+      "version": "1.0.5"
     },
     "ansi-align": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "js-base64": "3.7.3",
     "ngx-logger": "^5.0.11",
     "nostr-tools": "1.7.4",
+    "animiq-nip76-tools": "file:../../animiq-nip76-tools/dist",
     "qrcode": "^1.5.1",
     "qs": "^6.11.0",
     "rxjs": "7.5.6",


### PR DESCRIPTION
## WORK IN PROGRESS
- More cleanup work to do, but this version can demonstrate basic functionality
## Overview
- Each Private Channel message is encrypted with a unique key, signed with another unique key, and reveals no identifying information about the author or the intended recipient.
- Event signatures are verified through channel chainCode key derivation.
- Channel Keys are exchanged via event pointer strings, encrypted (by password or computed secret), which are the keys to a single nostrEvent called an _Invitation_.

### Links
- [nip76-tools](https://github.com/d-krause/animiq-nip76-tools)  (especially see [HDKIndex.ts](https://github.com/d-krause/animiq-nip76-tools/blob/main/src/core/keys/HDKIndex.ts) & [content classes](https://github.com/d-krause/animiq-nip76-tools/tree/main/src/core/content))
- [Client DEMO at https://nostr-nip76.web.app/private-channels](https://nostr-nip76.web.app/private-channels)
- [NIP-76 Pull Request](https://github.com/nostr-protocol/nips/pull/413)
