### PR TITLE
fix: Ensure long text content fits within mat-card element

### DIFF
--- a/angular/src/app/sign/sign.component.css
+++ b/angular/src/app/sign/sign.component.css
@@ -17,3 +17,6 @@
 .verify-status {
   text-align: center;
 }
+.overflow-auto{
+  overflow: auto;
+}

--- a/angular/src/app/sign/sign.component.html
+++ b/angular/src/app/sign/sign.component.html
@@ -17,7 +17,7 @@
           </mat-select>
         </mat-form-field>
 
-        <mat-card class="selectable">{{ address.value }}</mat-card
+        <mat-card class="selectable overflow-auto">{{ address.value }}</mat-card
         ><br />
 
         <mat-form-field class="sign-full-width" appearance="fill">


### PR DESCRIPTION
Applied CSS styles to control the appearance of the text content within the mat-card element, preventing overflow issues. The text is now contained within a <div> element with a maximum height and scrolling capability for improved user experience.
before: 
<img width="301" alt="IcFyeu0nJs" src="https://github.com/block-core/blockcore-wallet/assets/6504337/39ab4523-b022-40d8-a9e1-267b0c50b37f">

after:
<img width="301" alt="QiXmXa0RC8" src="https://github.com/block-core/blockcore-wallet/assets/6504337/e31b6a27-50aa-4652-92a0-85d451fca2b5">
